### PR TITLE
Update workflows to avoid using deprecated commands set-output and save-state

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -146,10 +146,9 @@ jobs:
 
       - name: Get Composer Cache Directory
         id: composer-cache
-        run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('/composer.lock') }}
@@ -157,7 +156,7 @@ jobs:
             ${{ runner.os }}-composer-
             
       - name: Cache node Directory
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('admin-dev/**/package-lock.json', 'tests/**/package-lock.json', 'themes/**/package-lock.json') }}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Update workflows to avoid using deprecated commands set-output and save-state
| Type?             | refacto
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| How to test?      | This PR is made in complementarity with this one from the core https://github.com/PrestaShop/PrestaShop/pull/30191 So they should be tested together by running automatic tests with this branch to test the core's PR The initial count of deprecation warnings was 135 before these changes It should be significantly lower
| Possible impacts? | ~

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
