### PR TITLE
Use PHP 8.1 as default php version

### DIFF
--- a/.github/workflows/pr_test.yml
+++ b/.github/workflows/pr_test.yml
@@ -40,7 +40,7 @@ on:
           - '8.0'
           - '8.1'
           - '8.2'
-        default: '7.4'
+        default: '8.1'
       node_version:
         type: choice
         description: Node version


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | To anticipate the future min version of PHP in version 9 we update the default value of PHP version in the test workflow to reduce the fact that people using might not modify it and would get failing workflows for most other PHP versions. The old PHP versions are still kept since they are useful for PrestaShop 8.0 and 8.1
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| Sponsor company   | ~
| How to test?      | ~
