### PR TITLE
Auto-retry failed jobs in PR test workflows

### DIFF
--- a/.github/workflows/auto_retry_failed_jobs.yml
+++ b/.github/workflows/auto_retry_failed_jobs.yml
@@ -1,0 +1,34 @@
+name: Auto-retry failed jobs
+on:
+  workflow_run:
+    workflows:
+      - 'Testing PrestaShop pull requests (without cache)'
+      - 'Testing Security PrestaShop pull requests (without cache)'
+    types:
+      - completed
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  retry:
+    name: Re-run failed jobs (attempt ${{ github.event.workflow_run.run_attempt }})
+    if: >
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.run_attempt < 6
+    runs-on: ubuntu-latest
+    steps:
+      - name: Re-run failed jobs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          echo "Workflow: $WORKFLOW_NAME"
+          echo "Run URL:  $RUN_URL"
+          echo "Attempt $RUN_ATTEMPT failed — triggering rerun of failed jobs only."
+          gh run rerun "$RUN_ID" --failed


### PR DESCRIPTION
## Summary

Adds a `workflow_run`-triggered workflow that automatically re-runs failed jobs in `pr_test_one` and `pr_security_test_one` (up to 6 attempts total).

Today, when a UI test workflow has flaky failures, we have to wait for **all** campaigns to finish before we can hit "Re-run failed jobs" — and often do this several times before everything goes green. This automates that loop.

### How it works

- Listens to `workflow_run: completed` for both `Testing PrestaShop pull requests (without cache)` and `Testing Security PrestaShop pull requests (without cache)`.
- If the run failed and `run_attempt < 6`, calls `gh run rerun <id> --failed` (the API equivalent of the "Re-run failed jobs" button).
- Original inputs (including the security workflow's `GH_TOKEN` input) are preserved across reruns — no secrets need to be re-passed.
- Uses the default `GITHUB_TOKEN` with `actions: write`.

### Notes

- The `workflow_run` listener only fires for workflow files that live on the **default branch**, so this only takes effect once merged to `main`.
- 6 attempts = original run + up to 5 retries. Tune the threshold in the `if:` condition if needed.
- No notification step on final failure — kept minimal for now, can be added later if useful.
- Constraint worth knowing: GitHub does **not** allow re-running jobs while the workflow run is still in progress (UI button and API both require `completed` state), so this fires after the whole run finishes. There's no way around that for matrix jobs without restructuring.

## Test plan

- [ ] Merge to `main`.
- [ ] Trigger `pr_test_one` against a PR known to produce flaky failures.
- [ ] Verify the `Auto-retry failed jobs` workflow appears in the Actions tab after the run completes.
- [ ] Verify failed jobs get re-queued automatically.
- [ ] Verify the retry loop stops at 6 attempts.